### PR TITLE
Add Cloudflare tunnel ingress for immich and authentik

### DIFF
--- a/funland/authentik/authentik/ingress.yaml
+++ b/funland/authentik/authentik/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: authentik-ingress
+  namespace: authentik
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+  - host: auth.batlab.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: authentik-application-server
+            port:
+              number: 80

--- a/funland/immich/immich/ingress.yaml
+++ b/funland/immich/immich/ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: immich-ingress
+  namespace: immich
+spec:
+  ingressClassName: cloudflare-tunnel
+  rules:
+  - host: immich.batlab.io
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: immich-application-server
+            port:
+              number: 2283


### PR DESCRIPTION
## Summary
- Add `funland/immich/immich/ingress.yaml` to expose `immich.batlab.io` externally via the `cloudflare-tunnel` ingress class
- Add `funland/authentik/authentik/ingress.yaml` to expose `auth.batlab.io` externally via the `cloudflare-tunnel` ingress class

Both follow the existing pattern used by `ntfy` and `privatebin`, routing through the `cloudflare-tunnel-ingress-controller` deployed in `funland/cloudflare/cloudflare/` so the services are reachable over Cloudflare Tunnel without opening any inbound firewall ports. Existing internal `HTTPRoute` resources for both apps are unchanged.

## Test plan
- [ ] Confirm ArgoCD syncs the new `Ingress` resources without errors
- [ ] Verify `immich.batlab.io` resolves and loads over the Cloudflare Tunnel
- [ ] Verify `auth.batlab.io` resolves and loads over the Cloudflare Tunnel


---
_Generated by [Claude Code](https://claude.ai/code/session_01CtUMewLP2YmJPz2uSDY8hM)_