### PR TITLE
chore(gateway-api): bump Gateway API CRDs from v1.5.0 to v1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ talosctl kubeconfig --nodes "${TALOS_IP}" --endpoints "${TALOS_IP}" --talosconfi
 Install the Gateway API CRDs before Cilium (Cilium's Gateway API integration requires these):
 
 ```sh
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
-kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.5.0/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/kubernetes-sigs/gateway-api/v1.6.1/config/crd/experimental/gateway.networking.k8s.io_tlsroutes.yaml
 ```
 
 ### 3. Install Cilium

--- a/funland/gateway-api/gateway-api-crds/crds/kustomization.yaml
+++ b/funland/gateway-api/gateway-api-crds/crds/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.0/standard-install.yaml
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.6.1/standard-install.yaml
 patches:
   - path: patch-tlsroute-v1alpha2.yaml
     target:

--- a/funland/gateway/gateway/README.md
+++ b/funland/gateway/gateway/README.md
@@ -16,7 +16,7 @@ This configuration relies on a Kubernetes Gateway API implementation being deplo
 
 The Gateway API CRDs are managed separately in `funland/gateway-api/gateway-api-crds/` and must be installed before these resources can be applied.
 
-**Current version**: v1.5.0
+**Current version**: v1.6.1
 
 The CRD installation uses an App of Apps pattern with **Server-Side Apply** (`ServerSideApply=true`) enabled. This is required because the Gateway API CRD manifests are large and can exceed the 1MB annotation limit used by client-side apply.
 


### PR DESCRIPTION
## Summary
- Bumps the Gateway API CRD install manifest from `v1.5.0` to `v1.6.1` in `funland/gateway-api/gateway-api-crds/crds/kustomization.yaml`
- Updates the version references in `README.md` and `funland/gateway/gateway/README.md` to match

## Breaking change review (v1.5.0 → v1.6.1)
Checked the v1.6.0 and v1.6.1 release notes for breaking changes and verified none apply to this repo's actual resources:
- `referencegrant.spec` made a required field — `funland/certificate/certificate/reference-grant.yaml` already sets `spec.from`/`spec.to`, unaffected.
- `idleTimeout` removed from the experimental `SessionPersistence` API — not used anywhere in this repo.
- `TCPRoute`/`UDPRoute` graduated to GA (`v1`), with `v1alpha2` deprecated — neither resource type is used anywhere in this repo.
- The `TLSRoute` CRD's `versions` array order is unchanged between v1.5.0 and v1.6.1 (`v1`, `v1alpha2`, `v1alpha3`), so the existing JSON patch in `patch-tlsroute-v1alpha2.yaml` (which targets index `1`/`v1alpha2` to mark it `served: true`) still applies correctly.
- Both `external-gateway.yaml` and `internal-gateway.yaml` already configure `tls.certificateRefs` on their HTTPS listeners.
- v1.6.1 itself is a patch release containing only test/conformance fixes, no breaking changes.

## Test plan
- [ ] Confirm ArgoCD syncs `gateway-api-crds-application` cleanly against the new CRD manifest (server-side apply)
- [ ] Confirm existing `Gateway`/`HTTPRoute`/`ReferenceGrant` resources remain valid after the CRD upgrade
- [ ] Spot-check `TLSRoute` alpha2 CRD is still served as expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01YRdrgiWqwRtQGeApVzMToB)_