### PR TITLE
Auto-merge minor/patch Renovate updates, raise PR limits, ignore archive, add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR change and why? -->
+
+## Type of change
+
+- [ ] Dependency update (Renovate)
+- [ ] New application / manifest
+- [ ] Configuration change to an existing application
+- [ ] Cluster infrastructure change (Cilium, ArgoCD, Talos, storage, networking)
+- [ ] Bug fix
+- [ ] Documentation
+
+## Affected applications / paths
+
+<!-- e.g. funland/monitoring/grafana -->
+
+-
+
+## Validation
+
+- [ ] Manifests are valid YAML / pass `kustomize build` or `helm template` where applicable
+- [ ] ArgoCD Application will sync without errors
+- [ ] Verified in a running cluster (describe below), or not applicable
+
+<!-- If verified, briefly describe what you checked (e.g. pod status, kubectl get applications) -->
+
+## Rollback plan
+
+<!-- How would this change be reverted if it causes issues? -->

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,11 @@
     "config:recommended"
   ],
   "ignorePaths": [
-    "funland/cnpg/cnpg-clusters/immich-cnpg-cluster.yaml"
+    "funland/cnpg/cnpg-clusters/immich-cnpg-cluster.yaml",
+    "archive/**"
   ],
-  "prHourlyLimit": 3,
-  "prConcurrentLimit": 5,
+  "prHourlyLimit": 6,
+  "prConcurrentLimit": 10,
   "pruneStaleBranches": true,
   "argocd": {
     "managerFilePatterns": [
@@ -52,6 +53,18 @@
       "matchDatasources": ["docker"],
       "matchFileNames": ["funland/**/deployment.yaml"],
       "groupName": "{{depName}} version updates"
+    },
+    {
+      "description": "Auto-merge minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Require PR review for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
     }
   ]
 }


### PR DESCRIPTION
- Automerge minor and patch dependency updates via packageRules; major updates
  still open a PR for review
- Raise prHourlyLimit/prConcurrentLimit so more updates can be processed
- Add archive/** to ignorePaths so Renovate stops scanning it
- Add .github/pull_request_template.md

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01X7YrNX4c7WNEXHXXGxrmbe