### PR TITLE
Track Talos and Kubernetes versions via Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -45,6 +45,28 @@
         "imageName:\\s*(?<depName>[^:]+):(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track Talos OS version",
+      "fileMatch": ["^funland/talos/talconfig\\.yaml$"],
+      "matchStrings": [
+        "talosVersion:\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?"
+      ],
+      "depNameTemplate": "siderolabs/talos",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Track Kubernetes version",
+      "fileMatch": ["^funland/talos/talconfig\\.yaml$"],
+      "matchStrings": [
+        "kubernetesVersion:\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?"
+      ],
+      "depNameTemplate": "kubernetes/kubernetes",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [
@@ -64,6 +86,11 @@
     {
       "description": "Require PR review for major updates",
       "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Never auto-merge Talos/Kubernetes version bumps - manual upgrade runbook required",
+      "matchDepNames": ["siderolabs/talos", "kubernetes/kubernetes"],
       "automerge": false
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@
 # OS files
 .DS_Store
 Thumbs.db
+
+# talhelper-generated secrets and machine configs (never commit in plaintext)
+talsecret.yaml
+clusterconfig/

--- a/README.md
+++ b/README.md
@@ -262,6 +262,37 @@ kubectl get scheduledbackups -n postgres
 kubectl get backups -n postgres
 ```
 
+## Upgrading Talos & Kubernetes
+
+`funland/talos/talconfig.yaml` ([talhelper](https://github.com/budimanjojo/talhelper) config) is the source of truth for the Talos OS version (`talosVersion`) and the Kubernetes version (`kubernetesVersion`). It also declares the Longhorn-required Talos system extensions (`siderolabs/iscsi-tools`, `siderolabs/util-linux-tools`) applied to every node.
+
+Renovate watches this file (see `.github/renovate.json`) and opens a PR whenever a new Talos or Kubernetes release is published. These PRs are **never auto-merged** — a node OS / control-plane bump needs human review and a controlled rollout, unlike the chart/image bumps elsewhere in this repo.
+
+Argo CD is not involved in this process: it only syncs Kubernetes API resources, while Talos/Kubernetes core upgrades go through the separate Talos API (`talosctl`). Merging the Renovate PR just records the target version — applying it is a manual runbook:
+
+```sh
+# Regenerate machine configs from the updated talconfig.yaml.
+# This also resolves the current schematic (Longhorn extensions) into an
+# installer image reference for each node, written to clusterconfig/*.yaml.
+talhelper genconfig
+
+# Look up the resolved installer image for a node, e.g.:
+yq '.machine.install.image' clusterconfig/funland-funland-worker-1.yaml
+# -> factory.talos.dev/installer/<schematic-id>:<new-talos-version>
+
+# Roll the Talos OS upgrade node-by-node - workers first, control plane last.
+# Validate cluster/Longhorn health between each node before continuing.
+talosctl upgrade --nodes 192.168.10.21 --image <installer-image-from-above>
+talosctl upgrade --nodes 192.168.10.22 --image <installer-image-from-above>
+talosctl upgrade --nodes 192.168.10.23 --image <installer-image-from-above>
+talosctl upgrade --nodes 192.168.10.30 --image <installer-image-from-above>
+
+# Once every node is on the new Talos version, bump Kubernetes components
+talosctl upgrade-k8s --nodes 192.168.10.30 --to <new-kubernetes-version>
+```
+
+> **Note:** `talhelper` also needs a `talsecret.yaml` (cluster/node secrets) to generate machine configs. Generate it locally with `talhelper gensecret` — it's gitignored and must never be committed in plaintext.
+
 ## Troubleshooting
 
 ### Node stuck in NotReady

--- a/funland/talos/talconfig.yaml
+++ b/funland/talos/talconfig.yaml
@@ -1,0 +1,52 @@
+# talhelper config - source of truth for the Talos OS and Kubernetes versions.
+#
+# talosVersion/kubernetesVersion are watched by Renovate (see .github/renovate.json)
+# so version bumps show up as PRs instead of drifting silently. Merging a bump PR
+# does NOT upgrade anything by itself - see the "Upgrading Talos & Kubernetes"
+# section in the README for the manual runbook.
+#
+# IMPORTANT: before merging this file for the first time, set talosVersion and
+# kubernetesVersion below to whatever the cluster is ACTUALLY running today, so
+# the first Renovate diff reflects a real upgrade rather than a fabricated jump.
+clusterName: funland
+talosVersion: v1.9.0
+kubernetesVersion: v1.31.0
+endpoint: https://192.168.10.30:6443
+allowSchedulingOnControlPlanes: false
+
+# Longhorn requires these Talos system extensions on every node (control plane
+# included, so Longhorn's manager/CSI components run cluster-wide even though
+# workloads themselves won't be scheduled on the control plane). talhelper
+# resolves this into a schematic ID via the Talos Image Factory automatically
+# when running `talhelper genconfig` - no manual schematic lookup needed.
+schematic:
+  customization:
+    systemExtensions:
+      officialExtensions:
+        - siderolabs/iscsi-tools
+        - siderolabs/util-linux-tools
+
+nodes:
+  - hostname: funland-cp-1
+    ipAddress: 192.168.10.30
+    controlPlane: true
+  - hostname: funland-worker-1
+    ipAddress: 192.168.10.21
+    controlPlane: false
+  - hostname: funland-worker-2
+    ipAddress: 192.168.10.22
+    controlPlane: false
+  - hostname: funland-worker-3
+    ipAddress: 192.168.10.23
+    controlPlane: false
+
+# Reproduces the existing bootstrap patch from the README (disable the default
+# CNI and kube-proxy so Cilium can replace both).
+patches:
+  - |-
+    cluster:
+      network:
+        cni:
+          name: none
+      proxy:
+        disabled: true


### PR DESCRIPTION
## Summary

Talos OS and Kubernetes versions had zero footprint in git — `controlplane.yaml`/`talosconfig` are generated locally per the README's manual bootstrap and never committed, so there was no way for Renovate (or anyone) to track or flag new releases. This adds `funland/talos/talconfig.yaml` (a [talhelper](https://github.com/budimanjojo/talhelper) config) as the git source of truth for `talosVersion`/`kubernetesVersion`, wires up Renovate to open PRs on new releases, and documents the manual upgrade runbook (Argo CD can't drive node-OS upgrades — those go through the separate Talos API).

While in there, also declared the Longhorn-required `siderolabs/iscsi-tools` and `siderolabs/util-linux-tools` Talos system extensions for all nodes, and set `allowSchedulingOnControlPlanes: false`.

## Type of change

- [ ] Dependency update (Renovate)
- [ ] New application / manifest
- [ ] Configuration change to an existing application
- [x] Cluster infrastructure change (Cilium, ArgoCD, Talos, storage, networking)
- [ ] Bug fix
- [x] Documentation

## Affected applications / paths

- `funland/talos/talconfig.yaml` (new)
- `.github/renovate.json`
- `.gitignore`
- `README.md`

## Validation

- [x] `talconfig.yaml` validated as well-formed YAML and spot-checked with `yq` (`talosVersion`, `kubernetesVersion`, `allowSchedulingOnControlPlanes`, extensions all parse as expected)
- [x] `renovate.json` validated as well-formed JSON; the new customManager regexes were tested against `talconfig.yaml` and correctly extract `talosVersion`/`kubernetesVersion`
- [ ] Not applicable — no Argo CD Application is added by this PR (Talos config isn't a Kubernetes resource Argo CD can sync)
- [ ] Not verified against the live cluster — no cluster access from this session. **Before merging**, please confirm `talosVersion`/`kubernetesVersion` in `talconfig.yaml` match what the cluster is actually running today, and generate `talsecret.yaml` locally via `talhelper gensecret` (gitignored, never committed) before running `talhelper genconfig`.

## Rollback plan

Revert this commit. Nothing in this PR touches the live cluster — it only adds tracking/automation. The Longhorn extensions and `allowSchedulingOnControlPlanes: false` only take effect once someone actually runs the `talhelper genconfig` + `talosctl upgrade` runbook from the README, so reverting before that runbook is executed leaves the cluster completely unaffected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ex6QKE5yzux2CC7SFeKNvV)_