### PR TITLE
Fix Renovate branch-update failure; bring READMEs in line with the live cluster

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -54,8 +54,7 @@
         "talosVersion:\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?"
       ],
       "depNameTemplate": "siderolabs/talos",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     },
     {
       "customType": "regex",
@@ -65,8 +64,7 @@
         "kubernetesVersion:\\s*[\"']?(?<currentValue>v[^\"'\\s]+)[\"']?"
       ],
       "depNameTemplate": "kubernetes/kubernetes",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ funland/                          # Cluster name
 ├── external-secrets/            # External Secrets Operator + 1Password
 ├── cnpg/                        # CloudNativePG operator + database clusters
 ├── longhorn-system/longhorn/    # Persistent storage
-├── monitoring/                  # Prometheus, Grafana, Loki, Promtail, metrics-server
+├── monitoring/                  # Prometheus, Grafana, metrics-server
+├── talos/                       # Talos/Kubernetes version tracking (talhelper)
 └── [app-namespace]/[app]/       # Application deployments
 ```
 
@@ -196,23 +197,26 @@ kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name
 | Application | Namespace | Description |
 |-------------|-----------|-------------|
 | AdGuard Home | adguard | DNS ad-blocking |
+| ArgoCD | argocd | GitOps continuous deployment |
 | Authentik | authentik | Identity provider / SSO |
 | Cert-Manager | cert-manager | TLS certificate automation |
+| Certificate | certificate | Wildcard TLS certificate |
 | Cilium | kube-system | CNI with Gateway API, BGP, Hubble observability |
+| CloudNativePG | postgres / cnpg-system | PostgreSQL operator + database clusters |
 | Cloudflare Tunnel | cloudflare | Cloudflare tunnel ingress controller |
-| etcd-operator | etcd-operator | etcd cluster operator (aenix-io) |
+| External Secrets Operator | external-secrets | Syncs secrets from 1Password |
+| Gateway | gateway | Gateway API Gateway resources (internal/external) |
+| Gateway API CRDs | gateway-api | Gateway API CRD definitions |
 | Grafana | monitoring | Metrics visualization |
-| Gravity DNS | gravity | Replicated DNS server powered by etcd |
 | Immich | immich | Photo/video management |
 | Jellyfin | media | Media server |
-| Loki | monitoring | Log aggregation |
 | Longhorn | longhorn-system | Distributed storage |
+| metrics-server | kube-system | Kubernetes resource metrics API |
 | ntfy | ntfy | Push notifications |
 | OpenSpeedTest | openspeedtest | Network speed testing |
+| 1Password Connect | 1password-connect | 1Password Connect server (ESO backend) |
 | Privatebin | privatebin | Encrypted pastebin |
 | Prometheus | monitoring | Metrics collection (kube-prometheus-stack) |
-| Promtail | monitoring | Log shipping agent |
-| Unifi Log Insight | unifi-log-insight | UniFi network log analysis |
 | Vaultwarden | vaultwarden | Bitwarden-compatible password manager |
 
 ## Network Architecture
@@ -228,11 +232,6 @@ kubectl get applications -n argocd -o jsonpath='{range .items[*]}{.metadata.name
 - Prometheus scrapes metrics from all services with ServiceMonitors
 - Cilium exports network metrics (DNS, TCP, HTTP, drops, flows)
 - Grafana dashboards available at `grafana.batlab.io`
-
-### Logging (Loki + Promtail)
-- Promtail runs as a DaemonSet, collecting logs from all pods
-- Loki aggregates logs in SingleBinary mode with Longhorn storage
-- Query logs via Grafana's Explore tab
 
 ### Network Observability (Hubble)
 - Hubble UI available at `hubble.batlab.io`

--- a/funland/cnpg/QUICKSTART.md
+++ b/funland/cnpg/QUICKSTART.md
@@ -7,16 +7,13 @@ The backup configuration has been set up with the following structure:
 ```
 funland/cnpg/
 ├── kustomization.yaml                    # Parent kustomization
-├── components/
-│   └── b2-backup/                        # Reusable backup template
-│       ├── backup-config.yaml            # Backup configuration
-│       └── kustomization.yaml            # Component definition
-├── external-secrets/
+├── cnpg-components/
 │   └── b2-backup-credentials.yaml        # B2 credentials from 1Password
 └── cnpg-clusters/
-    ├── kustomization.yaml                # Applies backup to all clusters
+    ├── kustomization.yaml                # Applies clusters + scheduled backups
     ├── scheduled-backups.yaml            # Daily backups at midnight
-    └── [cluster files...]                # Your existing cluster definitions
+    └── [cluster files...]                # Cluster definitions, each with its
+                                           # own inline spec.backup.barmanObjectStore
 ```
 
 ## Setup Steps
@@ -107,9 +104,9 @@ kubectl get cluster -n postgres -o jsonpath='{range .items[*]}{.metadata.name}{"
 
 ## Compression Options
 
-The default compression is **snappy** for optimal performance. To change:
+The default compression is **snappy** for optimal performance. Each cluster sets this independently in its own `spec.backup.barmanObjectStore` block. To change:
 
-Edit `funland/cnpg/cnpg-components/b2-backup/backup-config.yaml`:
+Edit the relevant cluster file, e.g. `funland/cnpg/cnpg-clusters/authentik-cnpg-cluster.yaml`:
 
 **For better compression (slower):**
 ```yaml

--- a/funland/cnpg/README-BACKUPS.md
+++ b/funland/cnpg/README-BACKUPS.md
@@ -9,23 +9,20 @@ The backup solution uses:
 - **Backblaze B2**: S3-compatible object storage for backup destination
 - **Barman**: PostgreSQL backup tool (integrated into CNPG)
 - **External Secrets Operator**: Pulls B2 credentials from 1Password
-- **Kustomize Components**: Reusable backup configuration template
+- **Inline per-cluster config**: Each cluster's `spec.backup.barmanObjectStore` block sets its own compression/retention/encryption/destination path (there is no shared Kustomize backup component)
 
 ## Directory Structure
 
 ```
 funland/cnpg/
 ├── cnpg-components/           # Components and configurations
-│   ├── b2-backup/            # Reusable backup configuration component
-│   │   └── ...              # Backup configuration files
 │   ├── b2-backup-credentials.yaml  # ExternalSecret for B2 credentials
 │   └── README.md
 ├── cnpg-clusters/            # PostgreSQL cluster definitions
-│   ├── kustomization.yaml    # Applies backup to all clusters
+│   ├── kustomization.yaml    # Applies clusters + scheduled backups
 │   ├── authentik-cnpg-cluster.yaml
 │   ├── immich-cnpg-cluster.yaml
 │   ├── vaultwarden-cnpg-cluster.yaml
-│   ├── vikunja-cnpg-cluster.yaml
 │   ├── scheduled-backups.yaml
 │   └── README.md
 ├── cnpg-operator/            # Operator configuration
@@ -86,7 +83,7 @@ kubectl describe cluster authentik-dbc -n postgres
 
 ### Compression Options
 
-The backup configuration uses **snappy** compression by default. You can change this in `funland/cnpg/cnpg-components/b2-backup/backup-config.yaml`:
+The backup configuration uses **snappy** compression by default. Each cluster sets this independently in its own `spec.backup.barmanObjectStore` block — e.g. `funland/cnpg/cnpg-clusters/authentik-cnpg-cluster.yaml`:
 
 **Available compression algorithms:**
 - `snappy`: Fast compression, moderate compression ratio (recommended for most cases)
@@ -103,7 +100,7 @@ data:
 
 ### Retention Policy
 
-Backups are retained for **30 days** by default. Change in `cnpg-components/b2-backup/backup-config.yaml`:
+Backups are retained for **30 days** by default. Change per-cluster in `cnpg-clusters/<app>-cnpg-cluster.yaml`:
 ```yaml
 backup:
   retentionPolicy: "30d"  # Format: <number>d (days), <number>w (weeks), <number>m (months)
@@ -159,7 +156,7 @@ kubectl get cluster authentik-dbc -n postgres -o jsonpath='{.status.lastSuccessf
 
 ## Scheduled Backups
 
-CNPG automatically performs continuous WAL archiving. To add scheduled full backups, create a `ScheduledBackup` resource:
+CNPG performs continuous WAL archiving automatically, and `funland/cnpg/cnpg-clusters/scheduled-backups.yaml` already defines a daily full backup for every cluster (`authentik-daily-backup`, `vaultwarden-daily-backup`, `immich-daily-backup`), applied via `cnpg-clusters/kustomization.yaml`:
 
 ```yaml
 apiVersion: postgresql.cnpg.io/v1
@@ -168,17 +165,15 @@ metadata:
   name: authentik-daily-backup
   namespace: postgres
 spec:
-  schedule: "0 0 2 * * *"  # Daily at 2 AM
+  schedule: "0 0 0 * * *"  # Daily at midnight
   backupOwnerReference: self
   cluster:
     name: authentik-dbc
   method: barmanObjectStore
+  immediate: true
 ```
 
-Apply it:
-```bash
-kubectl apply -f scheduled-backup.yaml
-```
+To add one for a new cluster, add a matching `ScheduledBackup` entry to `scheduled-backups.yaml` (it's already included in `cnpg-clusters/kustomization.yaml`, so no extra wiring is needed).
 
 ## Restore Operations
 
@@ -261,7 +256,6 @@ batcave-kubernetes/
 └── funland/
     └── postgres-backups/
         ├── authentik/
-        ├── vikunja/
         ├── vaultwarden/
         ├── immich/
 ```

--- a/funland/cnpg/cnpg-clusters/README.md
+++ b/funland/cnpg/cnpg-clusters/README.md
@@ -7,7 +7,6 @@ This directory contains the definitions for various PostgreSQL clusters managed 
 - `authentik-cnpg-cluster.yaml`: PostgreSQL cluster for Authentik.
 - `immich-cnpg-cluster.yaml`: PostgreSQL cluster for Immich.
 - `vaultwarden-cnpg-cluster.yaml`: PostgreSQL cluster for Vaultwarden.
-- `vikunja-cnpg-cluster.yaml`: PostgreSQL cluster for Vikunja.
 
 ## Scheduled Backups
 

--- a/funland/cnpg/cnpg-clusters/scheduled-backups.yaml
+++ b/funland/cnpg/cnpg-clusters/scheduled-backups.yaml
@@ -1,6 +1,6 @@
 ---
 # Scheduled backups for all CNPG clusters
-# These create daily full backups at 2 AM in addition to continuous WAL archiving
+# These create daily full backups at midnight in addition to continuous WAL archiving
 
 apiVersion: postgresql.cnpg.io/v1
 kind: ScheduledBackup

--- a/funland/cnpg/cnpg-components/README.md
+++ b/funland/cnpg/cnpg-components/README.md
@@ -5,7 +5,8 @@ This directory contains additional components and configurations related to [Clo
 ## Contents
 
 - `b2-backup-credentials.yaml`: Contains an ExternalSecret definition for fetching Backblaze B2 backup credentials.
-- `b2-backup/`: This subdirectory contains further configurations related to Backblaze B2 backups, such as `backup-config.yaml`.
+
+Per-cluster backup settings (compression, retention, encryption, destination path) are not defined here — they're set inline in each cluster's `spec.backup.barmanObjectStore` block under `funland/cnpg/cnpg-clusters/*.yaml`. There is no shared/reusable backup config in this directory.
 
 ## Secrets
 

--- a/funland/media/jellyfin/service.yaml
+++ b/funland/media/jellyfin/service.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/name: jellyfin
     app.kubernetes.io/instance: jellyfin
     # renovate: image=jellyfin/jellyfin
-    app.kubernetes.io/version: "10.11.5"
+    app.kubernetes.io/version: "10.11.11"
     app.kubernetes.io/component: media-server
     app.kubernetes.io/part-of: homelab
     app.kubernetes.io/managed-by: argocd

--- a/funland/monitoring/prometheus/README.md
+++ b/funland/monitoring/prometheus/README.md
@@ -6,4 +6,4 @@ Prometheus is an open-source systems monitoring and alerting toolkit. It collect
 
 ## Helm Chart
 
-This deployment uses the `prometheus` Helm chart from the [Prometheus Community Helm Charts repository](https://prometheus-community.github.io/helm-charts).
+This deployment uses the `kube-prometheus-stack` Helm chart from the [Prometheus Community Helm Charts repository](https://prometheus-community.github.io/helm-charts).


### PR DESCRIPTION
## Summary

Two unrelated fixes on this branch:

**1. Renovate branch-update failure** — After #526 merged, Renovate detected the new `talosVersion`/`kubernetesVersion` fields in `funland/talos/talconfig.yaml` (confirmed via the Dependency Dashboard, issue #24), but both update PRs failed with `⚠️ WARN: Error updating branch: update failure`. Root cause: the `extractVersionTemplate` I'd added to both new customManagers stripped the `v` prefix from the release tag when computing the new value, but the file's `currentValue` kept the `v` — a mismatched format (`v1.9.0 → 1.13.6` instead of `v1.9.0 → v1.13.6`). Removed the template from both customManagers in `.github/renovate.json`; no other regex manager in this file needed it, since `github-releases` tags are already clean `vX.Y.Z` strings.

**2. README/docs audit** — Per a follow-up request, audited every README in the repo against the actual deployed manifests and fixed what had drifted:
- Top-level `README.md`: removed `etcd-operator`/`Gravity DNS`/`Loki`/`Promtail`/`Unifi Log Insight` from the app table and the "Logging" section (all archived to `archive/funland/` and no longer deployed), added rows for apps that exist today but were never listed (ArgoCD, Certificate, CloudNativePG, External Secrets, Gateway, Gateway API CRDs, metrics-server, 1Password Connect), and fixed the repository structure diagram.
- `funland/monitoring/prometheus/README.md`: corrected the Helm chart name (`kube-prometheus-stack`, not `prometheus`).
- `funland/cnpg/*`: removed phantom Vikunja cluster/backup-path references (that app was archived) and corrected docs describing a shared `cnpg-components/b2-backup/backup-config.yaml` component that no longer exists — backup settings (compression/retention/encryption) are set inline per-cluster now. Also fixed the "Scheduled Backups" section, which described creating a `ScheduledBackup` as a to-do with a 2 AM example schedule, when `scheduled-backups.yaml` already defines these for every cluster at midnight.
- `funland/cnpg/cnpg-clusters/scheduled-backups.yaml`: fixed a stale top comment that still said "2 AM" instead of midnight.
- `funland/media/jellyfin/service.yaml`: synced the `app.kubernetes.io/version` label to the actual deployed image tag (`10.11.11`) — it isn't covered by Renovate's `deployment.yaml`-only `fileMatch`, so it had silently drifted from the Deployment's version.

## Type of change

- [x] Dependency update (Renovate)
- [ ] New application / manifest
- [ ] Configuration change to an existing application
- [ ] Cluster infrastructure change (Cilium, ArgoCD, Talos, storage, networking)
- [x] Bug fix
- [x] Documentation

## Affected applications / paths

- `.github/renovate.json`
- `README.md`
- `funland/cnpg/QUICKSTART.md`, `README-BACKUPS.md`, `cnpg-clusters/README.md`, `cnpg-clusters/scheduled-backups.yaml`, `cnpg-components/README.md`
- `funland/media/jellyfin/service.yaml`
- `funland/monitoring/prometheus/README.md`

## Validation

- [x] `renovate.json` validated as well-formed JSON; the `talosVersion`/`kubernetesVersion` regex captures still extract correctly with the template removed
- [x] Edited YAML files (`scheduled-backups.yaml`, `service.yaml`) parsed successfully
- [x] Every README claim was checked against the actual manifest it describes (chart names, versions, namespaces, file paths, backup schedule) rather than assumed
- [ ] Not verified against a live Renovate run for part 1 — after merge, check the retry checkbox for the two errored entries on the Dependency Dashboard (issue #24) or wait for the next scheduled run

## Rollback plan

Revert this commit/PR. Nothing here touches cluster-applied resources except the `jellyfin` Service label (cosmetic metadata only, no behavior change) — everything else is documentation or Renovate config.
