### PR TITLE
Exclude Talos/Kubernetes from the minor/patch automerge rule directly

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,7 @@
     {
       "description": "Auto-merge minor and patch updates",
       "matchUpdateTypes": ["minor", "patch"],
+      "excludeDepNames": ["siderolabs/talos", "kubernetes/kubernetes"],
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
## Summary

Follow-up to #526/#527: those PRs added a dedicated `packageRules` entry that sets `automerge: false` for `siderolabs/talos` and `kubernetes/kubernetes`, relying on it being the *last* entry in the `packageRules` array to win over the earlier "Auto-merge minor and patch updates" rule (Renovate applies matching rules in order, with later rules overriding earlier ones' fields for the same dependency).

That works today, but it's fragile — the guarantee depends entirely on array ordering. Anyone reordering `packageRules` later (e.g. adding a new rule after it, or reshuffling for readability) could silently let a Talos or Kubernetes update auto-merge again. Notably, a jump like `v1.9.0 → v1.13.6` is a semver *minor* bump, so it would qualify for the auto-merge rule if the exclusion ever stopped applying.

## Fix

Added `"excludeDepNames": ["siderolabs/talos", "kubernetes/kubernetes"]` directly to the "Auto-merge minor and patch updates" rule in `.github/renovate.json`. This makes it structurally impossible for that rule to ever match these two deps, independent of ordering — the existing standalone `automerge: false` rule for them stays in place as a second, self-documenting line of defense (and it also covers major updates, which the automerge rule never matched anyway).

## Type of change

- [x] Dependency update (Renovate)
- [ ] New application / manifest
- [ ] Configuration change to an existing application
- [ ] Cluster infrastructure change (Cilium, ArgoCD, Talos, storage, networking)
- [x] Bug fix
- [ ] Documentation

## Affected applications / paths

- `.github/renovate.json`

## Validation

- [x] `renovate.json` validated as well-formed JSON
- [ ] Not verified against a live Renovate run — config-only change, effect is only observable the next time a Talos/Kubernetes minor or patch update is detected

## Rollback plan

Revert this commit. No functional risk either way — worst case without this fix is relying on rule ordering, which is what the repo already had before this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Ex6QKE5yzux2CC7SFeKNvV)_