### PR TITLE
ci: add manifest validation checks so Renovate automerge has a real gate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -80,8 +80,7 @@
       "excludeDepNames": ["siderolabs/talos", "kubernetes/kubernetes"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true,
-      "requiredStatusChecks": null
+      "platformAutomerge": true
     },
     {
       "description": "Require PR review for major updates",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -80,7 +80,8 @@
       "excludeDepNames": ["siderolabs/talos", "kubernetes/kubernetes"],
       "automerge": true,
       "automergeType": "pr",
-      "platformAutomerge": true
+      "platformAutomerge": true,
+      "requiredStatusChecks": null
     },
     {
       "description": "Require PR review for major updates",

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -54,7 +54,9 @@ jobs:
 
       - name: Install kustomize
         run: |
-          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s /usr/local/bin
+          if ! command -v kustomize >/dev/null; then
+            curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s /usr/local/bin
+          fi
 
       - name: Validate kustomize builds
         run: |

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,0 +1,70 @@
+name: Validate manifests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate YAML syntax
+        run: |
+          python3 -m pip install --quiet pyyaml
+          python3 - <<'EOF'
+          import glob
+          import sys
+
+          import yaml
+
+          errors = []
+          files = sorted(set(glob.glob("**/*.yaml", recursive=True) + glob.glob("**/*.yml", recursive=True)))
+          for path in files:
+              if path.startswith(".git/"):
+                  continue
+              try:
+                  with open(path) as f:
+                      list(yaml.safe_load_all(f))
+              except yaml.YAMLError as e:
+                  errors.append(f"{path}: {e}")
+
+          if errors:
+              print(f"YAML syntax errors in {len(errors)} file(s):")
+              for e in errors:
+                  print(f"  {e}")
+              sys.exit(1)
+
+          print(f"Checked {len(files)} YAML file(s), no syntax errors.")
+          EOF
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz | tar xz kubeconform
+          sudo mv kubeconform /usr/local/bin/
+
+      - name: Validate Kubernetes manifest structure
+        run: |
+          # Only feed kubeconform actual Kubernetes resources (apiVersion/kind);
+          # kustomize patch fragments and the Talos talconfig use other schemas.
+          grep -lZ '^apiVersion:' -r --include='*.yaml' funland \
+            | xargs -0 kubeconform -strict -ignore-missing-schemas -summary
+
+      - name: Install kustomize
+        run: |
+          curl -sSL "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -s /usr/local/bin
+
+      - name: Validate kustomize builds
+        run: |
+          status=0
+          while IFS= read -r -d '' kfile; do
+            dir=$(dirname "$kfile")
+            echo "Building $dir"
+            if ! kustomize build "$dir" > /dev/null; then
+              echo "::error::kustomize build failed for $dir"
+              status=1
+            fi
+          done < <(find funland -name 'kustomization.yaml' -print0)
+          exit $status


### PR DESCRIPTION
## Summary

Renovate's `automerge: true` for minor/patch updates (`.github/renovate.json`) wasn't actually merging PRs. Root cause: this repo has no CI, so every commit's combined GitHub status comes back `pending` with zero checks — Renovate waits for status checks to succeed before automerging, and that wait never resolves. Confirmed on #533 and #534, both sitting open for days despite showing "Automerge: Enabled."

This PR adds a real CI check for Renovate to gate on, instead of bypassing status checks entirely:

- New `.github/workflows/validate.yaml`, running on every PR and push to `main`:
  - **YAML syntax** — parses every `.yaml`/`.yml` file with PyYAML
  - **kubeconform** — validates Kubernetes manifest structure against upstream schemas (`-ignore-missing-schemas` so CRDs like `Application`/`ExternalSecret`/`HTTPRoute` are skipped rather than failing; `-strict` on resources it does recognize; filtered to files that declare `apiVersion:` so it skips the Talos `talconfig.yaml` and a kustomize JSON6902 patch fragment, which aren't standalone Kubernetes resources)
  - **kustomize build** — builds every `kustomization.yaml` overlay to catch broken references
- `renovate.json` net diff against `main` is empty — an earlier commit on this branch added `requiredStatusChecks: null` as a stopgap, and this PR removes it again now that there's an actual check to wait on.

All three validation steps were run locally against this repo's real manifests before being wired into the workflow (97 YAML files parse clean, kubeconform passes with 0 errors, `kustomize build` succeeds against `funland/cnpg`).

## Type of change

- [x] Configuration change to an existing application
- [x] Bug fix
- [ ] Dependency update (Renovate)
- [ ] New application / manifest
- [ ] Cluster infrastructure change (Cilium, ArgoCD, Talos, storage, networking)
- [ ] Documentation

## Affected applications / paths

- `.github/renovate.json`
- `.github/workflows/validate.yaml` (new)

## Validation

- [x] Manifests are valid YAML / pass `kustomize build` or `helm template` where applicable
- [ ] ArgoCD Application will sync without errors (n/a — no manifest content changed)
- [ ] Verified in a running cluster (n/a — CI/config change only)

## Rollback plan

Revert this PR. Renovate would go back to never automerging minor/patch (the original bug), rather than back to the unsafe `requiredStatusChecks: null` bypass.

---
_Generated by [Claude Code](https://claude.ai/code/session_016jU1YyfX4PL3cMprsxpNS4)_